### PR TITLE
Remove documentation of no-longer-there final declaration on class

### DIFF
--- a/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
+++ b/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
@@ -76,8 +76,6 @@ import java.util.logging.Logger;
  * parameters.  It might come in handy the next time this kind of issue arises.
  * <p>
  * This Filter is written to have no external .jar dependencies aside from the Servlet API necessary to be a Filter.
- * <p>
- * This class is declared final because it is not designed for extension.
  *
  * @since cas-security-filter 1.1
  */


### PR DESCRIPTION
Class has not been final since 2.0.10 ( commit 91b8328ce11942c53c8b3c19779a461c1d0738a9 ), so no longer characterize it as `final` in the JavaDoc.