### PR TITLE
Document `onlyPostParameters`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,11 @@ parameters.
 
 If present the value of this parameter must be exactly `true` or `false`, with `false` as the default.
 
+### onlyPostParameters init-param
 
+The _optional_ init-param `onlyPostParameters` is a whitespace-delimited set of the names of
+request parameters the filter will allow only on POST type requests. The Filter will throw an
+exception when any of these parameters are present on requests of any other type.
 
 Configuration Examples
 ----------------------
@@ -142,7 +146,7 @@ Configuration Examples
 </filter-mapping>
 ```
 
-In this configuration, the Filter will scrutinize all request parameters, requiring that they not be multi-valued, and requiring that they not contain any of `% ? # &`.
+In this configuration, the Filter will scrutinize all request parameters, requiring that they not be multi-valued, requiring that they not contain any of `% ? # &`, and allowing request parameters regardless of whether the request is of type POST or not.
 
 ### Allow multi-valued parameters
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,36 @@ Likewise, you could use this Filter in front of a CAS Server to prevent unexpect
 
 This approach has the advantage of only blocking specific CAS protocol parameters, so that if you were to map the Filter in front of say the services management UI you can block unexpectedly multi-valued CAS protocol parameters without blocking submission of the services management edit screen where multiple user attributes are selected for release to a service (a legitimate case of a multi-valued attribute).
 
+### Limiting specific request parameters to POST-type requests
+
+You could use this filter to restrict to only POST-type requests those request
+parameters that you expect only in POST-type requests.
+
+For example, suppose you have a HTML form that submits a form via POST with
+parameters `formFieldOne` and `formFieldTwo`. This configuration would block
+requests that include these parameters in other types of requests, for example
+in GET requests.
+
+```xml
+<filter>
+  <filter-name>requestParameterFilter</filter-name>
+  <filter-class>org.apereo.cas.security.RequestParameterPolicyEnforcementFilter</filter-class>
+  <init-param>
+    <param-name>onlyPostParameters</param-name>
+    <param-value>formFieldOne formFieldTwo</param-value>
+  </init-param>
+  <init-param>
+    <param-name>charactersToForbid</param-name>
+    <param-value>none</param-value>
+  </init-param>
+</filter>
+...
+<filter-mapping>
+  <filter-name>requestParameterFilter</filter-name>
+  <url-pattern>/*</url-pattern>
+</filter-mapping>
+```
+
 ### An entirely novel configuration
 
 So, a neat thing about this Filter is that it has nothing to do with CAS and it has no dependencies at all other than the Servlet API, so on that fateful day when you discover that some Java web application has some problem involving illicit submissions of the semicolon character in a request parameter named `query`, you can plop this Filter in front of it and get back to safety.  Doing so will almost certainly just work, since this Filter has no external dependencies whatsoever except on the Servlet API that had to be present for that Web Application to be a Java web app anyway.

--- a/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
+++ b/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
@@ -60,6 +60,13 @@ import java.util.logging.Logger;
  * fails filter initialization.  The default set of characters disallowed is percent, hash, question mark,
  * and ampersand.
  * <p>
+ * You can limit a set of request parameters to only be allowed on requests of type POST by
+ * setting the init-param "onlyPostParameters" to a whitespace-delimited list of parameters.
+ * Unlike "parametersToCheck", this does not support the special value "*".
+ * Setting  "onlyPostParameters" to a blank value fails filter initialization.
+ * By default (when "onlyPostParameters" is not set), the filter does not limit request parameters
+ * to only POST requests.
+ * <p>
  * Setting any other init parameter other than these recognized by this Filter will fail Filter initialization.  This
  * is to protect the adopter from typos or misunderstandings in web.xml configuration such that an intended
  * configuration might not have taken effect, since that might have security implications.


### PR DESCRIPTION
#15 added the init-param `onlyPostParameters`. (So, feature present since 2.0.2). This catches up the JavaDoc on the relevant filter and the README to document this init-param.