### PR TITLE
Document that bad config no longer fails filter init by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,17 @@ Configuration options
 
 This Filter is optionally configured via Filter `init-param` in `web.xml`.
 
-In general the Filter is very persnickety about init-params, such that if you give it a configuration that the Filter is not totally sure it understands, it will fail Filter initialization.
+In general the Filter is very persnickety about init-params, such that if you give it a configuration that the Filter is not totally sure it understands, it will log
+an exception.
+
+**WARNING**: By default bad filter configuration will NOT fail filter
+initialization, and so it is possible to inadvertently configure the filter to
+e.g. have no effect. You SHOULD either be sure to monitor the logs for the
+SEVERE messages that will be logged if this filter believes its configuration is
+problematic, or set `FilterUtils.throwOnErrors` to true so that bad filter
+config fails Filter init and so fails context init, guaranteeing that you do not
+bring up an application intending to protect it with this filter but not
+successfully doing so due to configuration errors the filter is aware of.
 
 ### parametersToCheck init-param
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Configuration options
 
 This Filter is optionally configured via Filter `init-param` in `web.xml`.
 
-In general the Filter is very persnickety about init-params, such that if you give it a configuration that the Filter is not totally sure it understands, it will log
-an exception.
+In general the Filter is very persnickety about init-params, such that if you
+give it a configuration that the Filter is not totally sure it understands, it
+will log an exception.
 
 **WARNING**: By default bad filter configuration will NOT fail filter
 initialization, and so it is possible to inadvertently configure the filter to

--- a/src/main/java/org/apereo/cas/security/FilterUtils.java
+++ b/src/main/java/org/apereo/cas/security/FilterUtils.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public class FilterUtils {
     private static final Logger LOGGER = Logger.getLogger(FilterUtils.class.getName());
 
-    public static boolean throwOnErrors;
+    public static boolean throwOnErrors; // Java boolean defaults to false.
 
     private FilterUtils() {
     }

--- a/src/main/java/org/apereo/cas/security/FilterUtils.java
+++ b/src/main/java/org/apereo/cas/security/FilterUtils.java
@@ -28,6 +28,10 @@ import java.util.logging.Logger;
 /**
  * Utility classes.
  *
+ * Stateful: configure with whether logException should (re-)throw the logged
+ * exception, wrapping it in a new RuntimeException, via
+ * setThrowOnErrors(boolean). Defaults to false.
+ *
  * @author Misagh Moayyed
  * @since 2.1
  */

--- a/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
+++ b/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
@@ -43,21 +43,21 @@ import java.util.logging.Logger;
  * and ampersand characters, and enforcing no-multi-valued-ness.
  * <p>
  * You can turn off multi-value checking by setting the init-param "allowMultiValuedParameters" to "true".  Setting it
- * to "false" is a no-op retaining the default configuration.  Setting this parameter to any other value fails filter
+ * to "false" is a no-op retaining the default configuration.  Setting this parameter to any other value may fail filter
  * initialization.
  * <p>
  * You can change the set of request parameters being examined by setting the init-param "parametersToCheck" to a
  * whitespace delimited list of parameters to check.  Setting it to the special value "*" retains the default
- * behavior of checking all.  Setting it to a blank value fails filter initialization.  Setting it to a String
- * containing the asterisk token and any additional token fails filter initialization.
+ * behavior of checking all.  Setting it to a blank value may fail filter initialization.  Setting it to a String
+ * containing the asterisk token and any additional token may fail filter initialization.
  * <p>
  * You can change the set of characters looked for by setting the init-param "charactersToForbid" to a whitespace
  * delimited list of characters to forbid.  Setting it to the special value "none" disables the illicit character
  * blocking feature of this Filter (for the case where you only want to use the mutli-valued-ness blocking).
- * Setting it to a blank value fails filter initialization.
+ * Setting it to a blank value may fail filter initialization.
  * Setting it to a value that fails to parse perfectly
  * (e.g., a value with multi-character Strings between the whitespace delimiters)
- * fails filter initialization.  The default set of characters disallowed is percent, hash, question mark,
+ * may fail filter initialization.  The default set of characters disallowed is percent, hash, question mark,
  * and ampersand.
  * <p>
  * Setting any other init parameter other than these recognized by this Filter will fail Filter initialization.  This
@@ -65,7 +65,7 @@ import java.util.logging.Logger;
  * configuration might not have taken effect, since that might have security implications.
  * <p>
  * Setting the Filter to both allow multi-valued parameters and to disallow no characters would make the Filter a
- * no-op, and so fails Filter initialization since you probably meant the Filter to be doing something.
+ * no-op, and so may fail filter initialization since you probably meant the Filter to be doing something.
  * <p>
  * The intent of this filter is rough, brute force blocking of unexpected characters in specific CAS protocol related
  * request parameters.  This is one option as a workaround for patching in place certain Java CAS Client versions that
@@ -76,6 +76,14 @@ import java.util.logging.Logger;
  * parameters.  It might come in handy the next time this kind of issue arises.
  * <p>
  * This Filter is written to have no external .jar dependencies aside from the Servlet API necessary to be a Filter.
+ * <p>WARNING: Be sure that either FilterUtils throwOnErrors is set to true (not
+ * its default value) or that you are reliably monitoring logs for SEVERE level
+ * messages, so that you reliably notice if this filter is misconfigured. If
+ * FilterUtils throwOnErrors is false (its default value), this Filter can init
+ * in inconsistent configuration states. This is what is meant by
+ * "may fail filter initialization" above -- it'll fail only if FilterUtils
+ * throwOnError is true (not its default configuration), otherwise it will just
+ * log an exception.
  *
  * @since cas-security-filter 1.1
  */


### PR DESCRIPTION
Documents the changed behavior. As previously documented, bad config would fail filter init. As implemented, by default bad config will only log and not fail filter init. This updates the documentation to reflect reality.  (changed in fd11183 , so since v2.0.6).