### PR TITLE
Add "failSafe" init-param configuring FilterUtils.throwOnErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,31 @@ Configuration Examples
 
 In this configuration, the Filter will scrutinize all request parameters, requiring that they not be multi-valued, requiring that they not contain any of `% ? # &`, and allowing request parameters regardless of whether the request is of type POST or not.
 
+### Configuring to fail safely
+
+```xml
+<filter>
+  <filter-name>requestParameterFilter</filter-name>
+  <filter-class>org.apereo.cas.security.RequestParameterPolicyEnforcementFilter</filter-class>
+  <init-param>
+    <param-name>failSafe</param-name>
+    <param-value>true</param-value>
+  </init-param>
+</filter>
+...
+<filter-mapping>
+  <filter-name>requestParameterFilter</filter-name>
+  <url-pattern>/*</url-pattern>
+</filter-mapping>
+ ```
+
+ In this configuration, the Filter will fail filter initialization if there are
+ any configuration errors. There are not configuration errors here, so it will
+ not so fail. But this makes a safer starting point from which to add other
+ configuration, since if the filter detects errors in any of that additional
+ configuration, filter init will fail rather than the context initing with the
+ filter not providing the protection that you may have intended it to provide.
+
 ### Allow multi-valued parameters
 
 Multi-valued parameters are essential for supporting forms with multi-choice selectors where the form submission is legitimately represented as repeated parameter names with different values.

--- a/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
+++ b/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
@@ -171,6 +171,26 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
         this.onlyPostParameters = onlyPostParameters;
     }
 
+    /**
+     * Configure whether the filter should fail safe. Fail safe in this context
+     * means failing to init rather than initing with a configuration that's
+     * ambiguous and so may not be providing the intended protections. Fail
+     * dangerous in this context means initing regardless of configuration
+     * errors, which won't prevent the servlet context from initing, but which
+     * might init a servlet context without the protections intended by
+     * declaring and mapping this filter.
+     * <p>
+     * NOTE: This sets the throwOnErrors property of static singleton service
+     * FilterUtils. This configuration is global for all uses of FilterUtils,
+     * e.g. for usages in other filters.
+     * @param failSafe
+     */
+    public void setFailSafe(boolean failSafe) {
+      // if configured to fail safe, make configuration errors fatal so that
+      // this filter will not init() with known-problematic configuration.
+      FilterUtils.setThrowOnErrors(failSafe);
+    }
+
     public RequestParameterPolicyEnforcementFilter() {
         FilterUtils.configureLogging(getLoggerHandlerClassName(), LOGGER);
     }

--- a/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
+++ b/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
@@ -130,6 +130,12 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
     public static final String ONLY_POST_PARAMETERS = "onlyPostParameters";
 
     /**
+     * The name of the optional Filter init-param specifying that configuration
+     * errors should be fatal.
+     */
+    public static final String FAIL_SAFE = "failSafe";
+
+    /**
      * Set of parameter names to check.
      * Empty set represents special behavior of checking all parameters.
      */
@@ -320,6 +326,7 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
         recognizedParameterNames.add(PARAMETERS_TO_CHECK);
         recognizedParameterNames.add(ONLY_POST_PARAMETERS);
         recognizedParameterNames.add(CHARACTERS_TO_FORBID);
+        recognizedParameterNames.add(FAIL_SAFE);
         recognizedParameterNames.add(LOGGER_HANDLER_CLASS_NAME);
 
         while (initParamNames.hasMoreElements()) {

--- a/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
+++ b/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
@@ -67,6 +67,15 @@ import java.util.logging.Logger;
  * By default (when "onlyPostParameters" is not set), the filter does not limit request parameters
  * to only POST requests.
  * <p>
+ * You can set FilterUtils.throwOnErrors, and so whether configuration errors
+ * cause filter init to fail, by setting the init-param "failSafe". Setting
+ * failSafe to true makes configuration errors fatal thereby avoiding "unsafe"
+ * partially configured filter states. Setting failSafe to false sets
+ * FilterUtils.throwOnErrors to false (its default value).
+ * <p>
+ * NOTE: FilterUtils is a stateful static singleton service. Setting "failSafe"
+ * configures FilterUtils globally.
+ * <p>
  * Setting any other init parameter other than these recognized by this Filter will fail Filter initialization.  This
  * is to protect the adopter from typos or misunderstandings in web.xml configuration such that an intended
  * configuration might not have taken effect, since that might have security implications.
@@ -85,10 +94,11 @@ import java.util.logging.Logger;
  * This Filter is written to have no external .jar dependencies aside from the Servlet API necessary to be a Filter.
  * <p>WARNING: Be sure that either FilterUtils throwOnErrors is set to true (not
  * its default value) or that you are reliably monitoring logs for SEVERE level
- * messages, so that you reliably notice if this filter is misconfigured. If
- * FilterUtils throwOnErrors is false (its default value), this Filter can init
- * in inconsistent configuration states. This is what is meant by
- * "may fail filter initialization" above -- it'll fail only if FilterUtils
+ * messages, so that you reliably notice if this filter is misconfigured. You
+ * can set FilterUtils throwOnErrors by setting the "failSafe" init-param on
+ * this filter. If FilterUtils throwOnErrors is false (its default value), this
+ * Filter can init in inconsistent configuration states. This is what is meant
+ * by "may fail filter initialization" above -- it'll fail only if FilterUtils
  * throwOnError is true (not its default configuration), otherwise it will just
  * log an exception.
  *
@@ -213,7 +223,7 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
 
             FilterUtils.configureLogging(getLoggerHandlerClassName(), LOGGER);
 
-        // config failSafe first because specifies consequencesn of subsequent
+        // config failSafe first because specifies consequences of subsequent
         // config errors
         final String failSafeParam = filterConfig.getInitParameter(FAIL_SAFE);
 

--- a/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
+++ b/src/main/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilter.java
@@ -210,9 +210,18 @@ public class RequestParameterPolicyEnforcementFilter extends AbstractSecurityFil
     @Override
     public void init(final FilterConfig filterConfig) throws ServletException {
 
-        
+
             FilterUtils.configureLogging(getLoggerHandlerClassName(), LOGGER);
-        
+
+        // config failSafe first because specifies consequencesn of subsequent
+        // config errors
+        final String failSafeParam = filterConfig.getInitParameter(FAIL_SAFE);
+
+        if (null != failSafeParam) {
+          setFailSafe(
+            FilterUtils.parseStringToBooleanDefaultingToFalse(failSafeParam));
+        }
+
         // verify there are no init parameters configured that are not recognized
         // since an unrecognized init param might be the adopter trying to configure this filter in an important way
         // and accidentally ignoring that intent might have security implications.

--- a/src/test/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilterTests.java
+++ b/src/test/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilterTests.java
@@ -18,6 +18,7 @@
  */
 package org.apereo.cas.security;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
@@ -55,12 +56,13 @@ public final class RequestParameterPolicyEnforcementFilterTests {
 
     /* ========================================================================================================== */
 
+    @Before
+    public void beforeTests() {
+      FilterUtils.setThrowOnErrors(true);
+    }
+
     /* Tests for the Filter as a whole.
      */
-
-    static {
-        FilterUtils.setThrowOnErrors(true);
-    }
 
     /**
      * Test that setting failSafe projects through to the FilterUtils static
@@ -143,6 +145,9 @@ public final class RequestParameterPolicyEnforcementFilterTests {
       when(filterConfig.getInitParameter(RequestParameterPolicyEnforcementFilter.FAIL_SAFE))
               .thenReturn("true");
 
+      // precondition
+      FilterUtils.setThrowOnErrors(false);
+
       // behavior under test
       filter.init(filterConfig);
 
@@ -152,8 +157,6 @@ public final class RequestParameterPolicyEnforcementFilterTests {
 
     @Test
     public void testSettingFailSafeFalseFromInitParam() throws Exception{
-      // precondition
-      FilterUtils.setThrowOnErrors(true);
 
       // build test objects
       final RequestParameterPolicyEnforcementFilter filter = new RequestParameterPolicyEnforcementFilter();
@@ -174,9 +177,6 @@ public final class RequestParameterPolicyEnforcementFilterTests {
 
       // assertion
       assertFalse(FilterUtils.throwOnErrors);
-
-      // clean up
-      FilterUtils.setThrowOnErrors(true);
     }
 
     @Test

--- a/src/test/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilterTests.java
+++ b/src/test/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilterTests.java
@@ -63,6 +63,24 @@ public final class RequestParameterPolicyEnforcementFilterTests {
     }
 
     /**
+     * Test that setting failSafe projects through to the FilterUtils static
+     * singleton service.
+     */
+    @Test
+    public void testSetFailSafe() {
+      final RequestParameterPolicyEnforcementFilter filter =
+        new RequestParameterPolicyEnforcementFilter();
+
+      filter.setFailSafe(false);
+      assertFalse("Setting failSafe false should set FilterUtils.throwOnErrors to false.",
+        FilterUtils.throwOnErrors);
+
+      filter.setFailSafe(true);
+      assertTrue("Setting failSafe true should set FilterUtils.throwOnErrors to true.",
+      FilterUtils.throwOnErrors);
+    }
+
+    /**
      * Test that the Filter throws on init when unrecognized Filter init-param.
      * @throws RuntimeException on test success.
      */

--- a/src/test/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilterTests.java
+++ b/src/test/java/org/apereo/cas/security/RequestParameterPolicyEnforcementFilterTests.java
@@ -125,6 +125,61 @@ public final class RequestParameterPolicyEnforcementFilterTests {
     }
 
     @Test
+    public void testSettingFailSafeTrueFromInitParam() throws Exception{
+      // precondition
+      FilterUtils.setThrowOnErrors(false);
+
+      // build test objects
+      final RequestParameterPolicyEnforcementFilter filter = new RequestParameterPolicyEnforcementFilter();
+
+      // mock up filter config.
+      final Set<String> initParameterNames = new HashSet<String>();
+      initParameterNames.add(RequestParameterPolicyEnforcementFilter.FAIL_SAFE);
+      final Enumeration parameterNamesEnumeration = Collections.enumeration(initParameterNames);
+
+      final FilterConfig filterConfig = mock(FilterConfig.class);
+      when(filterConfig.getInitParameterNames()).thenReturn(parameterNamesEnumeration);
+
+      when(filterConfig.getInitParameter(RequestParameterPolicyEnforcementFilter.FAIL_SAFE))
+              .thenReturn("true");
+
+      // behavior under test
+      filter.init(filterConfig);
+
+      // assertion
+      assertTrue(FilterUtils.throwOnErrors);
+    }
+
+    @Test
+    public void testSettingFailSafeFalseFromInitParam() throws Exception{
+      // precondition
+      FilterUtils.setThrowOnErrors(true);
+
+      // build test objects
+      final RequestParameterPolicyEnforcementFilter filter = new RequestParameterPolicyEnforcementFilter();
+
+      // mock up filter config.
+      final Set<String> initParameterNames = new HashSet<String>();
+      initParameterNames.add(RequestParameterPolicyEnforcementFilter.FAIL_SAFE);
+      final Enumeration parameterNamesEnumeration = Collections.enumeration(initParameterNames);
+
+      final FilterConfig filterConfig = mock(FilterConfig.class);
+      when(filterConfig.getInitParameterNames()).thenReturn(parameterNamesEnumeration);
+
+      when(filterConfig.getInitParameter(RequestParameterPolicyEnforcementFilter.FAIL_SAFE))
+              .thenReturn("false");
+
+      // behavior under test
+      filter.init(filterConfig);
+
+      // assertion
+      assertFalse(FilterUtils.throwOnErrors);
+
+      // clean up
+      FilterUtils.setThrowOnErrors(true);
+    }
+
+    @Test
     public void configureSlf4jLogging() throws ServletException {
         final RequestParameterPolicyEnforcementFilter filter = new RequestParameterPolicyEnforcementFilter();
 


### PR DESCRIPTION
Enable configuring `FilterUtils.throwOnErrors` via `web.xml` configuration of the Filter.